### PR TITLE
perf: improve camelCaseProperty

### DIFF
--- a/modules/__tests__/camelCaseProperty-test.js
+++ b/modules/__tests__/camelCaseProperty-test.js
@@ -3,9 +3,17 @@ import camelCaseProperty from '../camelCaseProperty'
 describe('Camel casing properties', () => {
   it('should camel case properties', () => {
     expect(camelCaseProperty('transition-delay')).toEqual('transitionDelay')
+
     expect(camelCaseProperty('-webkit-transition-delay')).toEqual(
       'WebkitTransitionDelay'
     )
     expect(camelCaseProperty('-ms-transition')).toEqual('msTransition')
+
+    expect(camelCaseProperty('WebkitTransitionDelay')).toEqual(
+      'WebkitTransitionDelay'
+    )
+    expect(camelCaseProperty('WebkitFlex')).toEqual(
+      'WebkitFlex'
+    )
   })
 })

--- a/modules/camelCaseProperty.js
+++ b/modules/camelCaseProperty.js
@@ -1,10 +1,23 @@
-const DASH = /-([a-z])/g
-const MS = /^Ms/g
+function toLowerCaseFirstCharacter(value) {
+  return value.substr(0, 1).toLowerCase()  + value.substr(1);
+}
 
-function toUpper(match) {
-  return match[1].toUpperCase()
+function toUpperCaseFirstCharacter(value) {
+  return value.substr(0, 1).toUpperCase() + value.substr(1);
 }
 
 export default function camelCaseProperty(property) {
-  return property.replace(DASH, toUpper).replace(MS, 'ms')
+  // -ms-transition => ['', 'ms', 'transition']
+  // transition-delay => ['transition', 'delay']
+  // WebkitTransitionDelay => ['WebkitTransitionDelay']
+  const separatedByDash = property.split('-')
+
+  if (separatedByDash.length === 1) {
+    return property;
+  }
+
+  const inPascalCase = separatedByDash.map(toUpperCaseFirstCharacter).join('');
+  const shouldLowerCaseFirstChar = separatedByDash[0] !== '' || separatedByDash[1] === 'ms'
+
+  return shouldLowerCaseFirstChar ? toLowerCaseFirstCharacter(inPascalCase) : inPascalCase;
 }


### PR DESCRIPTION
In this PR I am trying to improve performance of `camelCaseProperty`.

### Why?

`camelCaseProperty` is used in `generateDeclarationReference`:

https://github.com/robinweser/fela/blob/97148419e7941dbd5867b35df6ac4de6c5ed3e55/packages/fela-utils/src/generateDeclarationReference.js#L4-L12

Which will be executed on each `renderRule()` call via `_renderStyleToClassNames`:

https://github.com/robinweser/fela/blob/97148419e7941dbd5867b35df6ac4de6c5ed3e55/packages/fela/src/createRenderer.js#L269-L275

With these changes I was able to improve perf of this function for ~30%: https://jsben.ch/oBOya

And for overall app perf:

#### `master` (i.e. before)

| Example                  | min    | avg    | median | max   |
| ------------------------ | ------ | ------ | ------ | ----- |
| ChatWithPopover.perf.tsx | 294.35 | 322.34 | 315.4  | 428.6 |

#### with changed function

| Example                  | min    | avg    | median | max    |
| ------------------------ | ------ | ------ | ------ | ------ |
| ChatWithPopover.perf.tsx | 270.76 | 295.09 | 290.8  | 379.12 |
| ChatWithPopover.perf.tsx | 271.16 | 292.21 | 286.07 | 391.41 |