### PR TITLE
Add simple cache in camelCaseProperty

### DIFF
--- a/modules/__tests__/camelCaseProperty-test.ts
+++ b/modules/__tests__/camelCaseProperty-test.ts
@@ -8,4 +8,8 @@ describe('Camel casing properties', () => {
     )
     expect(camelCaseProperty('-ms-transition')).toEqual('msTransition')
   })
+  it('should return same output on same input', () => {
+    expect(camelCaseProperty('border-color')).toEqual('borderColor')
+    expect(camelCaseProperty('border-color')).toEqual('borderColor')
+  })
 })

--- a/modules/camelCaseProperty.ts
+++ b/modules/camelCaseProperty.ts
@@ -1,10 +1,22 @@
+type CacheObject = {
+  [key: string]: string
+}
+
 const DASH = /-([a-z])/g
 const MS = /^Ms/g
+const cache: CacheObject = {}
 
 function toUpper(match: string) {
   return match[1].toUpperCase()
 }
 
 export default function camelCaseProperty(property: string) {
-  return property.replace(DASH, toUpper).replace(MS, 'ms')
+  if (cache.hasOwnProperty(property)) {
+    return cache[property]
+  }
+
+  const camelProp = property.replace(DASH, toUpper).replace(MS, 'ms')
+  cache[property] = camelProp
+
+  return camelProp
 }


### PR DESCRIPTION
Similar to hyphenate-style-name, we add a simple cache object to speed
up performance of `camelCaseProperty()` call.

Ref:
https://github.com/rexxars/hyphenate-style-name/blob/e5400abe204407d36364ffec21b00a62ca676c45/index.js#L11

Fix https://github.com/robinweser/css-in-js-utils/issues/13