### PR TITLE
Ignore CSS variables

### DIFF
--- a/modules/camelCaseProperty.ts
+++ b/modules/camelCaseProperty.ts
@@ -2,6 +2,7 @@ type CacheObject = {
   [key: string]: string
 }
 
+const CSS_VARIABLE = /^--/;
 const DASH = /-([a-z])/g
 const MS = /^Ms/g
 const cache: CacheObject = {}
@@ -15,7 +16,7 @@ export default function camelCaseProperty(property: string) {
     return cache[property]
   }
 
-  const camelProp = property.replace(DASH, toUpper).replace(MS, 'ms')
+  const camelProp = CSS_VARIABLE.test(property) ? property : property.replace(DASH, toUpper).replace(MS, 'ms')
   cache[property] = camelProp
 
   return camelProp


### PR DESCRIPTION
Otherwise:
```ts
camelCaseProperty("--my-css-var") // => "-MyCssVar"
```

There's a workaround downstream in [fela-dom/rehydration/rehydrateRules.js#L60](https://github.com/robinweser/fela/blob/master/packages/fela-dom/src/dom/rehydration/rehydrateRules.js#L60) that also motivates this change.

A similar fix is needed in [`hyphenateProperty()`](https://github.com/robinweser/css-in-js-utils/blob/master/modules/hyphenateProperty.ts#L3). (I'd recommend dropping the dependency on [`hyphenate-style-name`](https://github.com/rexxars/hyphenate-style-name/blob/main/index.js#L15), so the fix could be made here.)